### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is an open protocol that standardizes how applications provide context to LLMs developed by [Anthropic](https://www.anthropic.com/). Here we use the [MCP python-sdk](https://github.com/modelcontextprotocol/python-sdk) to create a MCP server that interfaces with Biomart via the [pybiomart](https://github.com/jrderuiter/pybiomart) package.
 
+<a href="https://glama.ai/mcp/servers/v5a3mlxviu">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/v5a3mlxviu/badge" alt="Biomart MCP server" />
+</a>
+
 ![Demo showing biomart-mcp in action](./assets/demo.png)
 
 There is a short [demo video](assets/mcp-demo.mp4) showing the MCP server in action on Claude Desktop.


### PR DESCRIPTION
This PR adds a badge for the [Biomart MCP](https://glama.ai/mcp/servers/v5a3mlxviu) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/v5a3mlxviu">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/v5a3mlxviu/badge" alt="Biomart MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.